### PR TITLE
Add cookie-backed sessions and login API

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { findUserByEmail, sanitizeUser } from '@/lib/auth/userStore'
+import { verifyPassword } from '@/lib/auth/password'
+import { createSession, SESSION_MAX_AGE } from '@/lib/auth/sessionStore'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const email = typeof body.email === 'string' ? body.email.trim() : ''
+    const password = typeof body.password === 'string' ? body.password : ''
+
+    if (!email || !password) {
+      return NextResponse.json({ message: 'Email và mật khẩu là bắt buộc' }, { status: 400 })
+    }
+
+    const user = findUserByEmail(email)
+    if (!user || !verifyPassword(password, user.passwordHash)) {
+      return NextResponse.json({ message: 'Email hoặc mật khẩu không đúng' }, { status: 401 })
+    }
+
+    const session = createSession(user.id)
+    const response = NextResponse.json({ user: sanitizeUser(user) })
+
+    response.cookies.set({
+      name: 'vilaw_session',
+      value: session.id,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: SESSION_MAX_AGE,
+      path: '/'
+    })
+
+    return response
+  } catch (error) {
+    console.error('Login error:', error)
+    return NextResponse.json({ message: 'Không thể đăng nhập. Vui lòng thử lại.' }, { status: 500 })
+  }
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { deleteSession } from '@/lib/auth/sessionStore'
+
+export async function POST() {
+  const sessionCookie = cookies().get('vilaw_session')
+  if (sessionCookie?.value) {
+    deleteSession(sessionCookie.value)
+  }
+
+  const response = NextResponse.json({ success: true })
+  response.cookies.set({ name: 'vilaw_session', value: '', maxAge: 0, path: '/' })
+  return response
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createUser, sanitizeUser } from '@/lib/auth/userStore'
+import { createSession, SESSION_MAX_AGE } from '@/lib/auth/sessionStore'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const name = typeof body.name === 'string' ? body.name.trim() : ''
+    const email = typeof body.email === 'string' ? body.email.trim() : ''
+    const password = typeof body.password === 'string' ? body.password : ''
+    const phone = typeof body.phone === 'string' ? body.phone.trim() : undefined
+
+    if (!name) {
+      return NextResponse.json({ message: 'Họ và tên là bắt buộc' }, { status: 400 })
+    }
+
+    if (!email) {
+      return NextResponse.json({ message: 'Email là bắt buộc' }, { status: 400 })
+    }
+
+    if (!password || password.length < 6) {
+      return NextResponse.json({ message: 'Mật khẩu phải có ít nhất 6 ký tự' }, { status: 400 })
+    }
+
+    const user = createUser({ name, email, password, phone })
+    const session = createSession(user.id)
+
+    const response = NextResponse.json({ user: sanitizeUser(user) })
+    response.cookies.set({
+      name: 'vilaw_session',
+      value: session.id,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: SESSION_MAX_AGE,
+      path: '/'
+    })
+
+    return response
+  } catch (error) {
+    console.error('Register error:', error)
+    const message = error instanceof Error ? error.message : 'Không thể đăng ký. Vui lòng thử lại.'
+    return NextResponse.json({ message }, { status: message === 'Tài khoản đã tồn tại' ? 409 : 500 })
+  }
+}

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { deleteSession, getSession, touchSession } from '@/lib/auth/sessionStore'
+import { getUserById, sanitizeUser } from '@/lib/auth/userStore'
+
+export async function GET() {
+  const sessionCookie = cookies().get('vilaw_session')
+  const session = getSession(sessionCookie?.value)
+
+  if (!session) {
+    if (sessionCookie) {
+      cookies().set('vilaw_session', '', { path: '/', maxAge: 0 })
+    }
+    return NextResponse.json({ message: 'Chưa đăng nhập' }, { status: 401 })
+  }
+
+  const user = getUserById(session.userId)
+  if (!user) {
+    deleteSession(session.id)
+    cookies().set('vilaw_session', '', { path: '/', maxAge: 0 })
+    return NextResponse.json({ message: 'Phiên không hợp lệ' }, { status: 401 })
+  }
+
+  touchSession(session.id)
+  return NextResponse.json({ user: sanitizeUser(user) })
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -145,10 +145,26 @@ export default function HomePage() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
 
   useEffect(() => {
-    try {
-      const saved = localStorage.getItem('vilaw_user')
-      setIsLoggedIn(!!saved)
-    } catch {}
+    let isMounted = true
+
+    const checkSession = async () => {
+      try {
+        const response = await fetch('/api/auth/session', { credentials: 'include' })
+        if (!isMounted) return
+        setIsLoggedIn(response.ok)
+      } catch (error) {
+        console.error('Unable to determine session', error)
+        if (isMounted) {
+          setIsLoggedIn(false)
+        }
+      }
+    }
+
+    checkSession()
+
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   return (

--- a/lib/auth/password.ts
+++ b/lib/auth/password.ts
@@ -1,0 +1,33 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'crypto'
+
+const KEY_LENGTH = 64
+
+export function hashPassword(password: string): string {
+  if (!password) {
+    throw new Error('Password is required to generate a hash')
+  }
+
+  const salt = randomBytes(16).toString('hex')
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH)
+  return `${salt}:${derivedKey.toString('hex')}`
+}
+
+export function verifyPassword(password: string, hashedValue: string): boolean {
+  if (!password || !hashedValue) {
+    return false
+  }
+
+  const [salt, key] = hashedValue.split(':')
+  if (!salt || !key) {
+    return false
+  }
+
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH)
+  const keyBuffer = Buffer.from(key, 'hex')
+
+  if (keyBuffer.length !== derivedKey.length) {
+    return false
+  }
+
+  return timingSafeEqual(derivedKey, keyBuffer)
+}

--- a/lib/auth/sessionStore.ts
+++ b/lib/auth/sessionStore.ts
@@ -1,0 +1,72 @@
+import { randomBytes } from 'crypto'
+
+export type SessionRecord = {
+  id: string
+  userId: string
+  createdAt: number
+  expiresAt: number
+}
+
+type GlobalWithSessionStore = typeof globalThis & {
+  __VILAW_SESSION_STORE?: Map<string, SessionRecord>
+}
+
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+export const SESSION_MAX_AGE = Math.floor(SESSION_TTL_MS / 1000)
+
+const globalWithStore = globalThis as GlobalWithSessionStore
+
+if (!globalWithStore.__VILAW_SESSION_STORE) {
+  globalWithStore.__VILAW_SESSION_STORE = new Map<string, SessionRecord>()
+}
+
+const sessionStore = globalWithStore.__VILAW_SESSION_STORE
+
+export function createSession(userId: string): SessionRecord {
+  const id = randomBytes(24).toString('hex')
+  const record: SessionRecord = {
+    id,
+    userId,
+    createdAt: Date.now(),
+    expiresAt: Date.now() + SESSION_TTL_MS
+  }
+
+  sessionStore.set(id, record)
+  return record
+}
+
+export function getSession(sessionId?: string | null): SessionRecord | null {
+  if (!sessionId) {
+    return null
+  }
+
+  const record = sessionStore.get(sessionId) || null
+  if (!record) {
+    return null
+  }
+
+  if (record.expiresAt < Date.now()) {
+    sessionStore.delete(sessionId)
+    return null
+  }
+
+  return record
+}
+
+export function deleteSession(sessionId?: string | null) {
+  if (!sessionId) {
+    return
+  }
+
+  sessionStore.delete(sessionId)
+}
+
+export function touchSession(sessionId: string) {
+  const record = sessionStore.get(sessionId)
+  if (!record) {
+    return
+  }
+
+  record.expiresAt = Date.now() + SESSION_TTL_MS
+  sessionStore.set(sessionId, record)
+}

--- a/lib/auth/userStore.ts
+++ b/lib/auth/userStore.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from 'crypto'
+import { hashPassword } from '@/lib/auth/password'
+
+export type UserLevel = 'normal' | 'pro' | 'admin'
+
+export interface StoredUser {
+  id: string
+  name: string
+  email: string
+  passwordHash: string
+  level: UserLevel
+  phone?: string
+  createdAt: string
+}
+
+type GlobalWithUserStore = typeof globalThis & {
+  __VILAW_USER_STORE?: Map<string, StoredUser>
+}
+
+const globalWithStore = globalThis as GlobalWithUserStore
+
+if (!globalWithStore.__VILAW_USER_STORE) {
+  globalWithStore.__VILAW_USER_STORE = new Map<string, StoredUser>()
+}
+
+const userStore = globalWithStore.__VILAW_USER_STORE
+
+if (userStore.size === 0) {
+  const seedUsers: Array<Omit<StoredUser, 'id' | 'passwordHash' | 'createdAt'> & { password: string }> = [
+    {
+      name: 'Nguyễn Văn A',
+      email: 'user@example.com',
+      password: 'user123',
+      level: 'normal',
+      phone: '0912345678'
+    },
+    {
+      name: 'Trần Thị B',
+      email: 'pro@example.com',
+      password: 'pro123',
+      level: 'pro',
+      phone: '0987654321'
+    },
+    {
+      name: 'Admin ViLaw',
+      email: 'admin@vilaw.com',
+      password: 'admin123',
+      level: 'admin',
+      phone: '0909090909'
+    }
+  ]
+
+  seedUsers.forEach(user => {
+    const id = randomUUID()
+    userStore.set(id, {
+      id,
+      name: user.name,
+      email: user.email.toLowerCase(),
+      passwordHash: hashPassword(user.password),
+      level: user.level,
+      phone: user.phone,
+      createdAt: new Date().toISOString()
+    })
+  })
+}
+
+export function findUserByEmail(email: string): StoredUser | undefined {
+  const normalized = email.toLowerCase()
+  for (const user of userStore.values()) {
+    if (user.email === normalized) {
+      return user
+    }
+  }
+  return undefined
+}
+
+export function getUserById(id: string): StoredUser | undefined {
+  return userStore.get(id)
+}
+
+interface CreateUserInput {
+  name: string
+  email: string
+  password: string
+  phone?: string
+  level?: UserLevel
+}
+
+export function createUser(input: CreateUserInput): StoredUser {
+  const email = input.email.toLowerCase()
+  if (findUserByEmail(email)) {
+    throw new Error('Tài khoản đã tồn tại')
+  }
+
+  const id = randomUUID()
+  const user: StoredUser = {
+    id,
+    name: input.name,
+    email,
+    passwordHash: hashPassword(input.password),
+    level: input.level ?? 'normal',
+    phone: input.phone,
+    createdAt: new Date().toISOString()
+  }
+
+  userStore.set(id, user)
+  return user
+}
+
+export function sanitizeUser(user: StoredUser): Omit<StoredUser, 'passwordHash'> {
+  const { passwordHash, ...rest } = user
+  return rest
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,5 +1,8 @@
 // Global type declarations for ViLaw
 
+import type { SessionRecord } from '@/lib/auth/sessionStore'
+import type { StoredUser } from '@/lib/auth/userStore'
+
 declare global {
   interface Window {
     apiService: any
@@ -8,6 +11,9 @@ declare global {
     RATE_LIMITS: any
     ERROR_CONFIG: any
   }
+
+  var __VILAW_SESSION_STORE: Map<string, SessionRecord> | undefined
+  var __VILAW_USER_STORE: Map<string, StoredUser> | undefined
 }
 
 export {}


### PR DESCRIPTION
## Summary
- add in-memory user and session stores with cookie-based login, register, session, and logout API routes
- update the login and demo experiences to call the new endpoints instead of relying on localStorage
- refresh the home page and user icon to read session state from the backend

## Testing
- not run (interactive ESLint setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_68e62055c504832fb9c7e084a5007a37